### PR TITLE
Modify browser to_dict method; Modify procs_monitor init, save_conf a…

### DIFF
--- a/ide_mon.py
+++ b/ide_mon.py
@@ -7,6 +7,7 @@ with daemon.DaemonContext():
     monitor = ProcMonitor()
     try:
         monitor.monitor_processes()
-        codetime.run()
-    except:
-        print("There was an error.  Check the logs for more information.")
+        if monitor.current_ide:
+            codetime.run()
+    except Exception as err:
+        print("There was an error:\n{err}.")

--- a/pkg/browser_lib.py
+++ b/pkg/browser_lib.py
@@ -92,5 +92,5 @@ class Browser:
         return {
             'name': browser or self.current_browser,
             'time_spent': self.browsers[self.current_browser].elapsed_time,
-            'tabs': list(self.browsers[self.current_browser].tabs)
+            'tabs': dict(self.browsers[self.current_browser].tabs)
         }

--- a/pkg/codetime_lib.py
+++ b/pkg/codetime_lib.py
@@ -21,7 +21,7 @@ class CodeTime:
         self.projects_dir = ''
         self.verbose = False
         self.ide_process = process
-        self.current_project
+        self.current_project = ''
 
     # ----------------------------------------------
     # ------------------ Observer ------------------
@@ -153,7 +153,7 @@ class CodeTime:
         pattern = 'name|dir|created|complete'
 
         if verbose:
-            pattern += '|date|time_spent|last_modified_date'
+            pattern += '|date|time_spent|last_modified_date|browser'
 
         for key in project:
             if re.fullmatch(pattern, key):

--- a/pkg/handlers.py
+++ b/pkg/handlers.py
@@ -26,7 +26,7 @@ class IdeHandler(events.FileSystemEventHandler):
         if not project:
             project = self.codetime.create_project(project_name)
 
-        self.codetime.current_project = project_name
+        self.codetime.current_project = project.name
 
         # Start tracking time spent in project
         project.add_time_spent(-project.start_time)
@@ -44,7 +44,7 @@ class IdeHandler(events.FileSystemEventHandler):
         observer.start()
 
     def on_closed(self, event, project_name=os.getcwd()):
-        if os.path.basename(event.src_path) == self.project.name:
+        if os.path.basename(event.src_path) == self.project.name or os.path.basename(event.src_path) == self.project.dir:
             project = self.codetime.get_project(project_name)
             project.add_time_spent(time.time() - project.start_time)
             project.update_last_modified(project.date)


### PR DESCRIPTION
…nd load_conf methods filtering existing 'coded' ides and browsers from conf file; Create procs_monitor on_created method, separating the loading and addition of saved additionl ides and browsers; Add conditional if process.current_ide is populated to run codetime.py; Add conditional for project.dir in case the project_name is not the cwd; Add project_name to create_project method call, was missing; Add import of ide_mon to IdeHandler in handlers.py to call the monitor function when ide is closed;